### PR TITLE
Remove httpinterface option

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,9 +4,9 @@ if [ ! -f /.mongodb_password_set ]; then
 fi
 
 if [ "$AUTH" == "yes" ]; then
-    export mongodb='/usr/bin/mongod --nojournal --auth --httpinterface --rest'
+    export mongodb='/usr/bin/mongod --nojournal --auth --rest'
 else
-    export mongodb='/usr/bin/mongod --nojournal --httpinterface --rest'
+    export mongodb='/usr/bin/mongod --nojournal --rest'
 fi
 
 if [ ! -f /data/db/mongod.lock ]; then


### PR DESCRIPTION
When I `docker run -d -p 27017:27017 -p 28017:28017 tutum/mongodb` after build : 

I have this output with `docker logs` :

```
error command line: unrecognised option '--httpinterface'
```
