### PR TITLE
Run mongo with exec instead of eval, in order receive docker TERM signal

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,10 +10,10 @@ else
 fi
 
 if [ ! -f /data/db/mongod.lock ]; then
-    eval $mongodb
+    exec $mongodb
 else
     export mongodb=$mongodb' --dbpath /data/db' 
     rm /data/db/mongod.lock
-    mongod --dbpath /data/db --repair && eval $mongodb
+    mongod --dbpath /data/db --repair && exec $mongodb
 fi
 


### PR DESCRIPTION
Related to  #7

Running mongod with exec instead of eval, allows receiving TERM signal from `docker stop`.
