### PR TITLE
Fix admin permissions

### DIFF
--- a/set_mongodb_password.sh
+++ b/set_mongodb_password.sh
@@ -19,7 +19,7 @@ while [[ RET -ne 0 ]]; do
 done
 
 echo "=> Creating an admin user with a ${_word} password in MongoDB"
-mongo admin --eval "db.addUser({user: 'admin', pwd: '$PASS', roles: [ 'userAdminAnyDatabase', 'dbAdminAnyDatabase' ]});"
+mongo admin --eval "db.addUser({user: 'admin', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
 mongo admin --eval "db.shutdownServer();"
 
 echo "=> Done!"


### PR DESCRIPTION
As explained here : http://stackoverflow.com/questions/23003391/how-do-i-add-an-admin-user-to-mongo-in-2-6

This modification avoid the message : 

```
Error while trying to show server startup warnings: not authorized on admin to execute command 
```
