### PR TITLE
Fix problem with shared volume + refact

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
-lockfile=/data/db/mongod.lock
+db_path=/data/db
+lockfile=$db_path/mongod.lock
 if [ -f $lockfile ]; then
     rm $lockfile
-    mongod --dbpath /data/db --repair
+    mongod --dbpath ${db_path} --repair
 fi
 
-if [ ! -f /.mongodb_password_set ]; then
+if [ ! -f $db_path/.mongodb_password_set ]; then
     /set_mongodb_password.sh
 fi
 
-cmd='/usr/bin/mongod --nojournal --httpinterface --rest'
+cmd='mongod --nojournal --httpinterface --rest'
 if [ "$AUTH" == "yes" ]; then
     cmd="$cmd --auth"
 fi
@@ -18,8 +19,8 @@ fi
 if [ ! -f $lockfile ]; then
     exec $cmd
 else
-    cmd="$cmd --dbpath /data/db"
+    cmd="$cmd --dbpath $db_path"
     rm $lockfile
-    mongod --dbpath /data/db --repair && exec $cmd
+    mongod --dbpath $db_path --repair && exec $cmd
 fi
 

--- a/set_mongodb_password.sh
+++ b/set_mongodb_password.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-if [ -f /.mongodb_password_set ]; then
+if [ -f /data/db/.mongodb_password_set ]; then
 	echo "MongoDB password already set!"
 	exit 0
 fi
 
-/usr/bin/mongod --smallfiles --nojournal &
+mongod --smallfiles --nojournal &
 
 PASS=${MONGODB_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${MONGODB_PASS} ] && echo "preset" || echo "random" )
@@ -19,11 +19,11 @@ while [[ RET -ne 0 ]]; do
 done
 
 echo "=> Creating an admin user with a ${_word} password in MongoDB"
-mongo admin --eval "db.addUser({user: 'admin', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
+mongo admin --eval "db.createUser({user: 'admin', pwd: '$PASS', roles:[{role:'root',db:'admin'}]});"
 mongo admin --eval "db.shutdownServer();"
 
 echo "=> Done!"
-touch /.mongodb_password_set
+touch /data/db/.mongodb_password_set
 
 echo "========================================================================"
 echo "You can now connect to this MongoDB server using:"


### PR DESCRIPTION
When using a shared volume from host its better to `touch` the `.mongodb_password_set` file into the VOLUME directory so the marker file is saved on the host, and in case of reattaching it to another container the database wont be populated again.

Also done some refact:

- no need the use the `/usr/bin` prefix with the mongod, since the binary is already placed into the $PATH upon installation
- DRY-ing the code in the `run.sh`, by making the `/data/db` env var
- method `addUser` is depricated in mongodb-2.6,  in favor of the new `createUser`  