### PR TITLE
Sets MongoDB to use a smaller default file size

### DIFF
--- a/2.6/Dockerfile
+++ b/2.6/Dockerfile
@@ -15,6 +15,7 @@ VOLUME /data/db
 
 ENV AUTH yes
 ENV JOURNALING yes
+ENV SMALLFILES no
 
 ADD run.sh /run.sh
 ADD set_mongodb_password.sh /set_mongodb_password.sh

--- a/2.6/run.sh
+++ b/2.6/run.sh
@@ -15,6 +15,10 @@ if [ "$OPLOG_SIZE" != "" ]; then
     cmd="$cmd --oplogSize $OPLOG_SIZE"
 fi
 
+if [ "$SMALLFILES" == "yes" ]; then
+    cmd="$cmd --smallfiles"
+fi
+
 $cmd &
 
 if [ ! -f /data/db/.mongodb_password_set ]; then

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -15,6 +15,7 @@ VOLUME /data/db
 ENV AUTH yes
 ENV STORAGE_ENGINE wiredTiger
 ENV JOURNALING yes
+ENV SMALLFILES no
 
 ADD run.sh /run.sh
 ADD set_mongodb_password.sh /set_mongodb_password.sh

--- a/3.0/run.sh
+++ b/3.0/run.sh
@@ -15,6 +15,10 @@ if [ "$OPLOG_SIZE" != "" ]; then
     cmd="$cmd --oplogSize $OPLOG_SIZE"
 fi
 
+if [ "$SMALLFILES" == "yes" ]; then
+    cmd="$cmd --smallfiles"
+fi
+
 $cmd &
 
 if [ ! -f /data/db/.mongodb_password_set ]; then

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -15,6 +15,7 @@ VOLUME /data/db
 ENV AUTH yes
 ENV STORAGE_ENGINE wiredTiger
 ENV JOURNALING yes
+ENV SMALLFILES no
 
 ADD run.sh /run.sh
 ADD set_mongodb_password.sh /set_mongodb_password.sh

--- a/3.2/run.sh
+++ b/3.2/run.sh
@@ -15,6 +15,10 @@ if [ "$OPLOG_SIZE" != "" ]; then
     cmd="$cmd --oplogSize $OPLOG_SIZE"
 fi
 
+if [ "$SMALLFILES" == "yes" ]; then
+    cmd="$cmd --smallfiles"
+fi
+
 $cmd &
 
 if [ ! -f /data/db/.mongodb_password_set ]; then

--- a/README.md
+++ b/README.md
@@ -112,5 +112,13 @@ In MongoDB 3.0 the variable `OPLOG_SIZE` can be used to specify the mongod oplog
 
 By default MongoDB allocates 5% of the available free disk space, but will always allocate at least 1 gigabyte and never more than 50 gigabytes.
 
+Sets MongoDB to use a smaller default file size.
+-----------------------------
+
+If you want to run MongoDB with [option --smallfiles](https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption--smallfiles) you can set the environment variable `SMALLFILES` as `yes`:
+
+        docker run -d -p 27017:27017 -p 28017:28017 -e SMALLFILES=yes tutum/mongodb
+
+By default is "no".
 
 **by http://www.tutum.co**


### PR DESCRIPTION
When I run mongo as a service in drone:
```yaml
pipeline
  ...
services:
  database:
    image: tutum/mongodb
    pull: true
    environment:
      - AUTH=no
```
I catch error:
```
2016-12-01T08:16:50.911+0000 [initandlisten] ERROR: Insufficient free space for journal files
0s
12
2016-12-01T08:16:50.911+0000 [initandlisten] Please make at least 3379MB available in /data/db/journal or use --smallfiles
```